### PR TITLE
Ported comparison-pattern to Python 3

### DIFF
--- a/compattern/dependency/__init__.py
+++ b/compattern/dependency/__init__.py
@@ -1,1 +1,1 @@
-from dep_pattern import match
+from .dep_pattern import match

--- a/compattern/dependency/conll.py
+++ b/compattern/dependency/conll.py
@@ -121,7 +121,7 @@ def init_token(lis, is_conllx=True):
 
 def conll_sent_to_tree(sent):
     """Reverses the bottom-up representation to produce a root-centred tree"""
-    reverse_deps = [[] for _ in xrange(len(sent.tokens))]
+    reverse_deps = [[] for _ in range(len(sent.tokens))]
     for fro, to in sent.iterate_edges():
         reverse_deps[to - 1].append(fro - 1)
     root = None

--- a/compattern/dependency/dep_pattern.py
+++ b/compattern/dependency/dep_pattern.py
@@ -60,8 +60,7 @@ def _match(node, pattern, limit=9999):
         slot = pattern.get('slot')
         for kid in pattern.get('kids', []):
             this_kid_matches = [m for k in node.kids for m in _match(k, kid)]
-            this_kid_matches = filter(lambda x: x is not None,
-                                      this_kid_matches)
+            this_kid_matches = [x for x in this_kid_matches if x is not None]
             if this_kid_matches or not kid.get('optional', False):
                                     # uglyish; means: don't append optional
                                     # slots
@@ -74,9 +73,9 @@ def _match(node, pattern, limit=9999):
             incompatible_duplicate = False
             d = {slot: node}
             for kid_match in assignment:
-                for label, matched_tok in kid_match.items():
+                for label, matched_tok in list(kid_match.items()):
                     add_it = True
-                    for other_label, other_tok in d.items():
+                    for other_label, other_tok in list(d.items()):
                         if matched_tok == other_tok:
                             if other_label in required_slots:
                                 if label in required_slots:
@@ -93,7 +92,7 @@ def _match(node, pattern, limit=9999):
             #if len(d) != len(set([item.id for item in d.values()])):
             #    # A node was matched twice and this is not cool
             #    continue
-            if all(slot in d.keys() for slot in required_slots):
+            if all(slot in list(d.keys()) for slot in required_slots):
                 all_matches.append(d)
     return all_matches
 

--- a/compattern/dependency/tests/test_conll.py
+++ b/compattern/dependency/tests/test_conll.py
@@ -5,8 +5,8 @@ from compattern.dependency import conll
 
 def test_read_french():
     """Test that conll.read understands French Bonsai output"""
-    line = (u"6\tchauffé\tchauffer\tV\tVPP\tg=m|m=part|n=s|t=past\t"
-            u"1100011\t5\tdep_coord\t_\t_")
+    line = ("6\tchauffé\tchauffer\tV\tVPP\tg=m|m=part|n=s|t=past\t"
+            "1100011\t5\tdep_coord\t_\t_")
     sentence = conll.read([line, '\n'])[0]
     assert len(sentence) == 1
     token = sentence[0]

--- a/compattern/dependency/tests/test_dep_pattern.py
+++ b/compattern/dependency/tests/test_dep_pattern.py
@@ -119,7 +119,7 @@ def test_like():
     sent, root = read(example_like, return_tree=True)[0]
     matches = match(root, seed_patterns.like)
     assert_greater(len(matches), 0)
-    assert_in('T', matches[0].keys())
+    assert_in('T', list(matches[0].keys()))
 
 
 def test_like_t1():

--- a/compattern/dependency/tests/test_fr.py
+++ b/compattern/dependency/tests/test_fr.py
@@ -5,7 +5,7 @@ from compattern.dependency.conll import read
 from compattern.dependency import match
 from compattern.dependency.fr_patterns import aussi
 
-ex_aussi = u"""\
+ex_aussi = """\
 1   Au  à   P+D P+D s=def   1111111 0   root    _   _
 2   XIe XIe A   ADJ s=ord   _   3   mod _   _
 3   siècle  siècle  N   NC  g=m|n=s|s=c 0101001 1   obj _   _

--- a/compattern/pyglarf_args.py
+++ b/compattern/pyglarf_args.py
@@ -18,7 +18,7 @@ def _safe_head(node):
 
 
 def _get_sbj(rel):
-    for role_a, role_b, _, arg_tree in rel.args.values():
+    for role_a, role_b, _, arg_tree in list(rel.args.values()):
         if (any('SBJ' in role for role in role_a) or 'SBJ' in role_b) and (
                 arg_tree is not None):
             return arg_tree
@@ -27,13 +27,13 @@ def _get_sbj(rel):
 def find_comparison_nodes(tree):
     comparison_nodes = []
     for rel in tree.rels():
-        for _, _, _, arg_trees in rel.args.values():
+        for _, _, _, arg_trees in list(rel.args.values()):
             for arg_tree in arg_trees:
                 if _safe_filter_comparator(_safe_head(arg_tree[0])):
                     comparison_nodes.append((rel, arg_tree))
                 #if _safe_filter_as_unary(arg_tree):
                 #    comparison_nodes.append((rel, arg_tree))
-        for _, _, arg_tree in rel.advs.values():
+        for _, _, arg_tree in list(rel.advs.values()):
             if _safe_filter_comparator(_safe_head(arg_tree)):
                 comparison_nodes.append((rel, arg_tree))
             if _safe_filter_as_unary(arg_tree):

--- a/compattern/resources/therex.py
+++ b/compattern/resources/therex.py
@@ -1,6 +1,6 @@
 # Query Thesaurus X
 
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 from xml.etree import cElementTree as ET
 
 THEREX = "http://ngrams.ucd.ie/therex2/"
@@ -9,7 +9,7 @@ THEREX_POETIC = THEREX + "common-nouns/poetic.action?member={}&xml=true"
 
 
 def shared_category(a, b, derived=True):
-    res = urllib2.urlopen(THEREX_SHARED.format(a, b))
+    res = urllib.request.urlopen(THEREX_SHARED.format(a, b))
     root = ET.parse(res)
     members = [(member.text.strip(), int(member.get('weight')))
                for member in root.find('Members')]
@@ -22,7 +22,7 @@ def shared_category(a, b, derived=True):
 
 
 def poetic_properties(a):
-    res = urllib2.urlopen(THEREX_POETIC.format(a))
+    res = urllib.request.urlopen(THEREX_POETIC.format(a))
     members = [(member.text.strip(), int(member.get('weight')))
                for member in ET.parse(res).find('PoeticQualities')]
     members.sort(key=lambda x: x[1], reverse=True)

--- a/scripts/fast_match.py
+++ b/scripts/fast_match.py
@@ -21,7 +21,7 @@ import sys
 import time
 import mmap
 import os
-import cPickle
+import pickle
 import argparse
 
 from sklearn.externals.joblib import Parallel, delayed
@@ -88,8 +88,8 @@ def get_chunks(fname, block_size=2 ** 20, delim="<s>"):
 
 def _nested(submatch, match):
     """Check whether submatch is nested in match"""
-    ids_submatch = set((key, tok.id) for key, tok in submatch.items())
-    id_match = set((key, tok.id) for key, tok in match.items())
+    ids_submatch = set((key, tok.id) for key, tok in list(submatch.items()))
+    id_match = set((key, tok.id) for key, tok in list(match.items()))
     return set.issubset(ids_submatch, id_match)
 
 
@@ -182,13 +182,13 @@ if __name__ == '__main__':
     if fmt not in ['turboparser', 'wacky']:
         raise argparse.ArgumentError('format should be turboparser or wacky')
     delim = '<s>' if fmt == 'wacky' else ''
-    print("Processing {}".format(sys.argv[1]))
+    print(("Processing {}".format(sys.argv[1])))
     t0 = time.time()
     matches = Parallel(n_jobs=32, verbose=1)(delayed(process)(args.infile,
                                                               chunk, fmt)
                                              for chunk
                                              in get_chunks(args.infile,
                                                            delim=delim))
-    print("{} sentences matched".format(sum(len(m) for m in matches)))
-    print("Completed in {:.2f}".format(time.time() - t0))
-    cPickle.dump(matches, args.outfile)
+    print(("{} sentences matched".format(sum(len(m) for m in matches))))
+    print(("Completed in {:.2f}".format(time.time() - t0)))
+    pickle.dump(matches, args.outfile)

--- a/scripts/minibnc.py
+++ b/scripts/minibnc.py
@@ -20,7 +20,7 @@ for f in glob(PATH + '*.yaml'):
     f = open(f, encoding='utf-8')
     examples.extend(load(f))
 
-sents, ctxs, gfs, gts = zip(*examples)
+sents, ctxs, gfs, gts = list(zip(*examples))
 f = None
 only_glarf = open("bnc_similes/{}/only_glarf.txt".format(sys.argv[1]), "w",
                   encoding="utf-8")
@@ -32,7 +32,7 @@ for ii, (sent, ctx, gf, gt, dep) in enumerate(zip(sents, ctxs, gfs, gts,
                                                   dep_parse)):
     dep = dep[1]
     if ii % 20 == 0:
-        print '.'
+        print('.')
         if f:
             f.close()
         f = open('bnc_similes/{}/{:03d}.txt'.format(sys.argv[1], ii / 20), 'w',
@@ -62,22 +62,22 @@ for ii, (sent, ctx, gf, gt, dep) in enumerate(zip(sents, ctxs, gfs, gts,
         print_to.append(only_dep)
 
     for dest in print_to:
-        print >> dest, sent
-        print >> dest
-        print >> dest, "Glarf:"
+        print(sent, file=dest)
+        print(file=dest)
+        print("Glarf:", file=dest)
         for arg in args:
-            print >> dest, "T: {T}\nE: {E}\nP: {P}\nC: {C}\nV: {V}\n".format(
-                **arg)
-        print >> dest, "\nDep:"
+            print("T: {T}\nE: {E}\nP: {P}\nC: {C}\nV: {V}\n".format(
+                **arg), file=dest)
+        print("\nDep:", file=dest)
         for arg in dep_args:
-            arg = {key: unicode(val.form, errors="ignore")
-                   for key, val in arg.iteritems()}
+            arg = {key: str(val.form, errors="ignore")
+                   for key, val in arg.items()}
             for K in 'TEPCV':
                 if K not in arg:
                     arg[K] = '--'
-            print >> dest, "T: {T}\nE: {E}\nP: {P}\nC: {C}\nV: {V}\n".format(
-                **arg)
-        print >> dest, "==="
+            print("T: {T}\nE: {E}\nP: {P}\nC: {C}\nV: {V}\n".format(
+                **arg), file=dest)
+        print("===", file=dest)
 
-print matches
-print dep_matches
+print(matches)
+print(dep_matches)

--- a/scripts/simple_match.py
+++ b/scripts/simple_match.py
@@ -8,7 +8,7 @@ provided.
 By default this prints the dependency root of each comparison slot (topic,
 vehicle, etc) but the entire subtrees are extracted and available.
 """
-from __future__ import print_function
+
 import fileinput
 
 from compattern.dependency import match
@@ -27,5 +27,5 @@ if __name__ == '__main__':
         for pat in patterns:
             for m in match(root, pat):
                 print("\n".join("{}: {}".format(key, val.form)
-                                for key, val in m.items()))
+                                for key, val in list(m.items())))
                 print()

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,11 @@ setup(
     name='comparison_pattern',
     description='Scripts for mining comparison patterns from text',
     version=compattern.__version__,
+    packages=[
+    	'compattern',
+    	'compattern.dependency',
+    	'compattern.resources',
+    ],
     author='Vlad Niculae',
     author_email='vlad@vene.ro',
     classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f]


### PR DESCRIPTION
This pull request ports comparison-pattern to python 3, the work was done mostly automatically with the `2to3` tool. Furthermore it fixes the import in `compattern.depency.__init__.py`, which now uses relative imports. Finally, the setup.py file was changed to actually install the package(s).

This pull request fixes the problem mentioned in Issue #2.